### PR TITLE
Add setting to prevent 0 amount contributions

### DIFF
--- a/custom_php/CRM/Contact/Page/View/Purchases.php
+++ b/custom_php/CRM/Contact/Page/View/Purchases.php
@@ -23,9 +23,13 @@ class CRM_Contact_Page_View_Purchases extends CRM_Core_Page {
 		) );
 		$this->assign( 'orders', $orders );
 		$this->assign( 'uid', $uid );
-		$this->assign( 'newOrderUrl', apply_filters('woocommerce_civicrm_add_order_url', add_query_arg(array(	'post_type' => 'shop_order',
-																																																							'user_id' => $uid,
-																																																						),admin_url('post-new.php')) ,$uid ));
+		$this->assign(
+			'newOrderUrl',
+			apply_filters('woocommerce_civicrm_add_order_url', add_query_arg(
+				array( 'post_type' => 'shop_order', 'user_id' => $uid ),
+				admin_url('post-new.php')) ,$uid
+			)
+		);
 		parent::run();
 	}
 }

--- a/includes/class-woocommerce-civicrm-manager.php
+++ b/includes/class-woocommerce-civicrm-manager.php
@@ -501,6 +501,11 @@ class Woocommerce_CiviCRM_Manager {
 	 * @param object $order The order object
 	 */
 	public function add_contribution( $cid, &$order ) {
+
+		// bail if order is 'free' (0 amount) and 0 amount setting is enabled
+		if ( WCI()->helper->check_yes_no_value( get_option( 'woocommerce_civicrm_ignore_0_amount_orders', false ) ) && $order->get_total() == 0 )
+			return false;
+
 		$debug['cid']=$cid;
 		$order_id = $order->get_id();
 		$order_date = $order->get_date_paid();

--- a/includes/class-woocommerce-civicrm-settings-tab.php
+++ b/includes/class-woocommerce-civicrm-settings-tab.php
@@ -219,7 +219,13 @@ class Woocommerce_CiviCRM_Settings_Tab {
 				'type' => 'checkbox',
 				'desc' => __( 'WARNING, DATA LOSS!! If enabled, this option will replace Woocommerce\'s States/Countries with CiviCRM\'s States/Provinces, you WILL lose any existing State/Country data for existing Customers. Any Woocommerce Settings that relay on State/Country will have to be reconfigured.', 'woocommerce-civicrm' ),
 				'id'   => 'woocommerce_civicrm_replace_woocommerce_states'
-      ),
+			),
+			'woocommerce_civicrm_ignore_0_amount_orders' => array(
+				'name' => __( 'Don\'t create 0 amount contributions', 'woocommerce-civicrm' ),
+				'type' => 'checkbox',
+				'desc' => __( 'If enabled, this option will not create contributions for orders with a total of 0, i.e. free products (using a coupon).', 'woocommerce-civicrm' ),
+				'id'   => 'woocommerce_civicrm_ignore_0_amount_orders'
+			),
 			'section_end' => array(
 				'type' => 'sectionend',
 				'id' => 'woocommerce_civicrm_section_end'


### PR DESCRIPTION
## Overview
Adds a new setting to prevent 0 amount contributions.
## Before
All orders create a contribution, with no way to prevent it.
## After
A _Don't create 0 amount contributions_ setting is available, if enabled, 0 amount contributions are not created.

<img width="1263" alt="0_amount_contributions" src="https://user-images.githubusercontent.com/3038096/59843411-6c96ce00-9350-11e9-820c-7420c21b2b85.png">

## Comments
This is particularly useful for free products (i.e. using a _free_ coupon) if you don't want a contribution created.