### PR TITLE
Add setting to remove order tab for non customer contacts

### DIFF
--- a/includes/class-woocommerce-civicrm-orders-contact-tab.php
+++ b/includes/class-woocommerce-civicrm-orders-contact-tab.php
@@ -130,6 +130,10 @@ class Woocommerce_CiviCRM_Orders_Contact_Tab {
 	public function add_orders_contact_tab( $tabsetName, &$tabs, $context ) {
 		$uid = abs(CRM_Core_BAO_UFMatch::getUFId( $context['contact_id'] ));
 
+		// bail if contact has no orders and hide order is enabled
+		if ( WCI()->helper->check_yes_no_value( get_option( 'woocommerce_civicrm_hide_orders_tab_for_non_customers', false ) ) && ! $this->count_orders( $uid ) )
+			return;
+
 		$url = CRM_Utils_System::url( 'civicrm/contact/view/purchases', "reset=1&uid=$uid&no_redirect=1");
 
 		$tabs[] = array( 'id'    => 'woocommerce-orders',

--- a/includes/class-woocommerce-civicrm-settings-tab.php
+++ b/includes/class-woocommerce-civicrm-settings-tab.php
@@ -226,6 +226,12 @@ class Woocommerce_CiviCRM_Settings_Tab {
 				'desc' => __( 'If enabled, this option will not create contributions for orders with a total of 0, i.e. free products (using a coupon).', 'woocommerce-civicrm' ),
 				'id'   => 'woocommerce_civicrm_ignore_0_amount_orders'
 			),
+			'woocommerce_civicrm_hide_orders_tab_for_non_customers' => array(
+				'name' => __( 'Hide orders tab for non customers', 'woocommerce-civicrm' ),
+				'type' => 'checkbox',
+				'desc' => __( 'If enabled, this option will remove the WooCommerce Orders tab in the contact summary page for non customers contacts.', 'woocommerce-civicrm' ),
+				'id'   => 'woocommerce_civicrm_hide_orders_tab_for_non_customers'
+			),
 			'section_end' => array(
 				'type' => 'sectionend',
 				'id' => 'woocommerce_civicrm_section_end'


### PR DESCRIPTION
## Overview
Adds a new setting to remove/hide the WooCommerce Orders tab for non customer contacts.
## Before
The WooCommerce Orders tab shows for all contacts, regardless if they are a customer or not.
## After
A new _Hide orders tab for non customers_ is available, if enabled, the WooCommerce Orders tab is hidden/removed for non customer contacts.

<img width="1263" alt="hide_orders_tab" src="https://user-images.githubusercontent.com/3038096/59843937-8dabee80-9351-11e9-9c99-90dedae37388.png">
