### PR TITLE
Add orders tab only on contact summary screen

### DIFF
--- a/includes/class-woocommerce-civicrm-orders-contact-tab.php
+++ b/includes/class-woocommerce-civicrm-orders-contact-tab.php
@@ -128,6 +128,10 @@ class Woocommerce_CiviCRM_Orders_Contact_Tab {
 	 * @return array $setting_tabs The setting tabs array
 	 */
 	public function add_orders_contact_tab( $tabsetName, &$tabs, $context ) {
+
+		// bail if not on contact summary screen
+		if ( $tabsetName != 'civicrm/contact/view' ) return;
+
 		$uid = abs(CRM_Core_BAO_UFMatch::getUFId( $context['contact_id'] ));
 
 		// bail if contact has no orders and hide order is enabled


### PR DESCRIPTION
## Overview
Prevents the WooCommerce Orders tab from displaying in other screens/pages like Mange Events.
## Before
The WooCommerce Orders tab would show/display in screens/pages like the Manage Events page.

<img width="1263" alt="events_tab" src="https://user-images.githubusercontent.com/3038096/59844323-83d6bb00-9352-11e9-994f-ccd3e0970e91.png">

## After
The WooCommerce Orders tab only shows/displays in the Contact Summary screen.
