### PR TITLE
CIVIWOO-13: Really only add campaign_id if we have one.

### DIFF
--- a/includes/class-woocommerce-civicrm-manager.php
+++ b/includes/class-woocommerce-civicrm-manager.php
@@ -581,7 +581,6 @@ class Woocommerce_CiviCRM_Manager {
 			'receive_date' => $order_paid_date,
 			'contribution_status_id' => 'Pending',
 			'note' => $this->create_detail_string( $items ),
-			'campaign_id' => $woocommerce_civicrm_campaign_id,
 			'line_items' => [],
 		];
 


### PR DESCRIPTION
Was getting no contributions added, error messages like `[info] '0' is not a valid option for field campaign_id`

The `campaign_id` parameter was still in the array initialiser, so the condition to check for a valid campaign id was pointless.  This small changes fixes it.